### PR TITLE
Resolved Code Checker Errors

### DIFF
--- a/checklisteditor.php
+++ b/checklisteditor.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/checklisteditor.php
+++ b/checklisteditor.php
@@ -101,12 +101,12 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
             $mode = gradingform_checklist_controller::DISPLAY_EDIT_FULL;
             $module = array('name'=>'gradingform_checklisteditor', 'fullpath'=>'/grade/grading/form/checklist/js/checklisteditor.js',
                 'strings' => array(array('confirmdeletegroup', 'gradingform_checklist'), array('confirmdeleteitem', 'gradingform_checklist'),
-                    array('groupempty', 'gradingform_checklist'), array('itemempty', 'gradingform_checklist'), ['maxlengthalert', 'gradingform_checklist']
+                    array('groupempty', 'gradingform_checklist'), array('itemempty', 'gradingform_checklist'), ['maxlengthalert', 'gradingform_checklist'],
                 ));
             $PAGE->requires->js_init_call('M.gradingform_checklisteditor.init', array(
                     array('name' => $this->getName(),
                         'grouptemplate' => $renderer->group_template($mode, $data['options'], $this->getName()),
-                        'itemtemplate' => $renderer->item_template($mode, $data['options'], $this->getName())
+                        'itemtemplate' => $renderer->item_template($mode, $data['options'], $this->getName()),
                     )),
                 true, $module);
         } else {

--- a/checklisteditor.php
+++ b/checklisteditor.php
@@ -53,7 +53,7 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
      * @param array $helpbuttonargs array of arguments to make a help button
      * @param string $function function name to call to get html
      */
-    public function setHelpButton($helpbuttonargs, $function='helpbutton'){
+    public function setHelpButton($helpbuttonargs, $function='helpbutton') {
         debugging('component setHelpButton() is not used any more, please use $mform->setHelpButton() instead');
     }
 
@@ -99,7 +99,7 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
         $data = $this->prepare_data(null, $this->wasvalidated);
         if (!$this->_flagFrozen) {
             $mode = gradingform_checklist_controller::DISPLAY_EDIT_FULL;
-            $module = array('name'=>'gradingform_checklisteditor', 'fullpath'=>'/grade/grading/form/checklist/js/checklisteditor.js',
+            $module = array('name' => 'gradingform_checklisteditor', 'fullpath' => '/grade/grading/form/checklist/js/checklisteditor.js',
                 'strings' => array(array('confirmdeletegroup', 'gradingform_checklist'), array('confirmdeleteitem', 'gradingform_checklist'),
                     array('groupempty', 'gradingform_checklist'), array('itemempty', 'gradingform_checklist'), ['maxlengthalert', 'gradingform_checklist'],
                 ));
@@ -190,7 +190,7 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
                 $group['items']['NEWID'.($i++)]['score'] = 1;
 
                 // add more items so there are at least 3 in the new group. Score is 1 by default
-                for ($i= $i; $i < 3; $i++) {
+                for ($i = $i; $i < 3; $i++) {
                     $group['items']['NEWID'.$i]['score'] = 1;
                 }
                 // set other necessary fields (definition) for the items in the new group
@@ -239,7 +239,7 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
                     }
                 }
 
-                //sortorder for items
+                // sortorder for items
                 $itemsortorder = 1;
                 foreach (array_keys($items) as $itemid) {
                     $items[$itemid]['sortorder'] = $itemsortorder++;
@@ -326,7 +326,7 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
                 $maxid = (int)$matches[1];
             }
         }
-        return 'NEWID'.($maxid+1);
+        return 'NEWID' . ($maxid + 1);
     }
 
 
@@ -370,7 +370,7 @@ class MoodleQuickForm_checklisteditor extends HTML_QuickForm_input {
      * @return array
      */
     public function exportValue(&$submitValues, $assoc = false) {
-        $value =  $this->prepare_data($this->_findValue($submitValues));
+        $value = $this->prepare_data($this->_findValue($submitValues));
         return $this->_prepareValue($value, $assoc);
     }
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/edit.php
+++ b/edit.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/edit_form.php
+++ b/edit_form.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/edit_form.php
+++ b/edit_form.php
@@ -50,7 +50,7 @@ class gradingform_checklist_editchecklist extends moodleform {
         $form->setType('returnurl', PARAM_LOCALURL);
 
         // name
-        $form->addElement('text', 'name', get_string('name', 'gradingform_checklist'), array('size'=>52));
+        $form->addElement('text', 'name', get_string( 'name' , 'gradingform_checklist'), array('size' => 52));
         $form->addRule('name', get_string('required'), 'required');
         $form->setType('name', PARAM_TEXT);
 
@@ -68,7 +68,7 @@ class gradingform_checklist_editchecklist extends moodleform {
         // checklist editor
         $element = $form->addElement('checklisteditor', 'checklist', get_string('checklist', 'gradingform_checklist'));
         $form->setType('checklist', PARAM_RAW);
-        //$element->freeze(); // TODO freeze checklist editor if needed
+        // $element->freeze(); // TODO freeze checklist editor if needed
 
         $buttonarray = array();
         $buttonarray[] = &$form->createElement('submit', 'savechecklist', get_string('savechecklist', 'gradingform_checklist'));

--- a/lang/en/gradingform_checklist.php
+++ b/lang/en/gradingform_checklist.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/lib.php
+++ b/lib.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/lib.php
+++ b/lib.php
@@ -47,7 +47,7 @@ class gradingform_checklist_controller extends gradingform_controller {
     /** checklist display mode: Preview the checklist design (for person with manage permission) */
     const DISPLAY_PREVIEW       = 3;
     /** checklist display mode: Preview the checklist (for people being graded) */
-    const DISPLAY_PREVIEW_GRADED= 8;
+    const DISPLAY_PREVIEW_GRADED = 8;
     /** checklist display mode: For evaluation, enabled (teacher grades a student) */
     const DISPLAY_EVAL          = 4;
     /** checklist display mode: For evaluation, with hidden fields */
@@ -426,7 +426,7 @@ class gradingform_checklist_controller extends gradingform_controller {
         $new->checklist = array('groups' => array(), 'options' => $old->checklist['options']);
         $newgroupid = 1;
         $newitemid = 1;
-        foreach ($old->checklist['groups'] as  $oldgroup) {
+        foreach ($old->checklist['groups'] as $oldgroup) {
             unset($oldgroup['id']);
             if (isset($oldgroup['items'])) {
                 foreach ($oldgroup['items'] as $olditemid => $olditem) {
@@ -769,7 +769,7 @@ class gradingform_checklist_instance extends gradingform_instance {
 
         foreach ($data['groups'] as $groupid => $group) {
             foreach($group['items'] as $itemid => $record) {
-                //handle deletions later
+                // handle deletions later
                 if (empty($record['remark']) && empty($record['id'])) {
                     continue;
                 }
@@ -845,7 +845,7 @@ class gradingform_checklist_instance extends gradingform_instance {
             }
         }
 
-        $gradeoffset = ($curscore-$scores['minscore'])/($scores['maxscore']-$scores['minscore'])*($maxgrade-$mingrade);
+        $gradeoffset = ($curscore - $scores['minscore']) / ($scores['maxscore'] - $scores['minscore']) * ($maxgrade - $mingrade);
         if ($this->get_controller()->get_allow_grade_decimals()) {
             return $gradeoffset + $mingrade;
         }
@@ -861,7 +861,7 @@ class gradingform_checklist_instance extends gradingform_instance {
      */
     public function render_grading_element($page, $gradingformelement) {
         if (!$gradingformelement->_flagFrozen) {
-            $module = array('name'=>'gradingform_checklist', 'fullpath'=>'/grade/grading/form/checklist/js/checklist.js');
+            $module = array('name' => 'gradingform_checklist', 'fullpath' => '/grade/grading/form/checklist/js/checklist.js');
             $page->requires->js_init_call('M.gradingform_checklist.init', array(array('name' => $gradingformelement->getName())), true, $module);
             $mode = gradingform_checklist_controller::DISPLAY_EVAL;
         } else {
@@ -895,7 +895,7 @@ class gradingform_checklist_instance extends gradingform_instance {
                     $newchecked = null;
                     if (isset($value['groups'][$groupid]['items'][$itemid]['remark'])) $newremark = $value['groups'][$groupid]['items'][$itemid]['remark'];
                     if (isset($value['groups'][$groupid]['items'][$itemid]['id'])) $newchecked = !empty($value['groups'][$groupid]['items'][$itemid]['id']);
-                    if ($newchecked != !empty($item['checked']) || $newremark != $item['remark']) {
+                if ($newchecked != !empty($item['checked']) || $newremark != $item['remark']) {
                         $haschanges = true;
                 }
             }

--- a/lib.php
+++ b/lib.php
@@ -464,7 +464,7 @@ class gradingform_checklist_controller extends gradingform_controller {
             'noclean' => false,
             'trusted' => false,
             'filter' => true,
-            'context' => $context
+            'context' => $context,
         );
         return format_text($description, $this->definition->descriptionformat, $formatoptions);
     }
@@ -630,7 +630,7 @@ class gradingform_checklist_controller extends gradingform_controller {
             'showitempointstudent' => 1,
             'enableitemremarks' => 1,
             'enablegroupremarks' => 1,
-            'showremarksstudent' => 1
+            'showremarksstudent' => 1,
         );
         return $options;
     }

--- a/lib.php
+++ b/lib.php
@@ -832,7 +832,7 @@ class gradingform_checklist_instance extends gradingform_instance {
         }
         sort($graderange);
         $mingrade = $graderange[0];
-        $maxgrade = $graderange[sizeof($graderange) - 1];
+        $maxgrade = $graderange[count($graderange) - 1];
 
         $curscore = 0;
         foreach ($grade['groups'] as $groupid => $group) {

--- a/preview.php
+++ b/preview.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/renderer.php
+++ b/renderer.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/renderer.php
+++ b/renderer.php
@@ -324,20 +324,27 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
         $classsuffix = ''; // CSS suffix for class of the main div. Depends on the mode
         switch ($mode) {
             case gradingform_checklist_controller::DISPLAY_EDIT_FULL:
-                $classsuffix = ' editor editable'; break;
+                $classsuffix = ' editor editable'; 
+                break;
             case gradingform_checklist_controller::DISPLAY_EDIT_FROZEN:
-                $classsuffix = ' editor frozen';  break;
+                $classsuffix = ' editor frozen';
+                break;
             case gradingform_checklist_controller::DISPLAY_PREVIEW:
             case gradingform_checklist_controller::DISPLAY_PREVIEW_GRADED:
-                $classsuffix = ' editor preview';  break;
+                $classsuffix = ' editor preview';
+                break;
             case gradingform_checklist_controller::DISPLAY_EVAL:
-                $classsuffix = ' evaluate editable'; break;
+                $classsuffix = ' evaluate editable';
+                break;
             case gradingform_checklist_controller::DISPLAY_EVAL_FROZEN:
-                $classsuffix = ' evaluate frozen';  break;
+                $classsuffix = ' evaluate frozen';
+                break;
             case gradingform_checklist_controller::DISPLAY_REVIEW:
-                $classsuffix = ' review';  break;
+                $classsuffix = ' review';
+                break;
             case gradingform_checklist_controller::DISPLAY_VIEW:
-                $classsuffix = ' view';  break;
+                $classsuffix = ' view';
+                break;
         }
 
         $checklisttemplate = html_writer::start_tag('div', array('id' => 'checklist-{NAME}', 'class' => 'clearfix gradingform_checklist'.$classsuffix));

--- a/renderer.php
+++ b/renderer.php
@@ -423,7 +423,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
         $scoredpoints = 0;
         $cnt = 0;
         foreach ($groups as $id => $group) {
-            $group['class'] = $this->get_css_class_suffix($cnt++, sizeof($groups) - 1);
+            $group['class'] = $this->get_css_class_suffix($cnt++, count($groups) - 1);
             $group['id'] = $id;
             $itemsstr = '';
             $itemcnt = 0;
@@ -434,7 +434,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
             }
             foreach ($group['items'] as $itemid => $item) {
                 $item['id'] = $itemid;
-                $item['class'] = $this->get_css_class_suffix($itemcnt++, sizeof($group['items']) - 1);
+                $item['class'] = $this->get_css_class_suffix($itemcnt++, count($group['items']) - 1);
                 $item['checked'] = !empty($groupvalue['items'][$itemid]['checked']);
                 if ($item['checked'] && ($mode == gradingform_checklist_controller::DISPLAY_EVAL_FROZEN || $mode == gradingform_checklist_controller::DISPLAY_REVIEW || $mode == gradingform_checklist_controller::DISPLAY_VIEW)) {
                     $item['class'] .= ' checked';
@@ -504,7 +504,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
      */
     public function display_instances($instances, $defaultcontent, $cangrade) {
         $return = '';
-        if (sizeof($instances)) {
+        if (count($instances)) {
             $return .= html_writer::start_tag('div', array('class' => 'advancedgrade'));
             $idx = 0;
             foreach ($instances as $instance) {

--- a/renderer.php
+++ b/renderer.php
@@ -546,7 +546,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
             $html .= get_string('regrademessage1', 'gradingform_checklist');
             $selectoptions = array(
                 0 => get_string('regradeoption0', 'gradingform_checklist'),
-                1 => get_string('regradeoption1', 'gradingform_checklist')
+                1 => get_string('regradeoption1', 'gradingform_checklist'),
             );
             $html .= html_writer::select($selectoptions, $elementname.'[regrade]', $value, false);
         } else {

--- a/renderer.php
+++ b/renderer.php
@@ -119,7 +119,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
             if ($mode == gradingform_checklist_controller::DISPLAY_EVAL) {
                 $labelforremark = html_writer::tag('label', get_string('groupremark', 'gradingform_checklist', $group['description']),
                         array('class' => 'hiddenelement', 'for' => '{NAME}-groups-{GROUP-id}-items-0-remark'));
-                $input = $labelforremark . html_writer::tag('textarea', htmlspecialchars($currentremark),
+                $input = $labelforremark . html_writer::tag('textarea', htmlspecialchars($currentremark, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),
                         array('id' => '{NAME}-groups-{GROUP-id}-items-0-remark', 'name' => '{NAME}[groups][{GROUP-id}][items][0][remark]', 'cols' => '10', 'rows' => '5'));
                 $grouptemplate .= html_writer::tag('div', $input, array('class' => 'remark'));
             } else if ($mode == gradingform_checklist_controller::DISPLAY_EVAL_FROZEN) {
@@ -281,7 +281,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
             if ($mode == gradingform_checklist_controller::DISPLAY_EVAL) {
                 $labelforremark = html_writer::tag('label', get_string('itemremark', 'gradingform_checklist', $item['definition']),
                         array('class' => 'hiddenelement', 'for' => '{NAME}-groups-{GROUP-id}-items-{ITEM-id}-remark-input'));
-                $input = $labelforremark . html_writer::tag('textarea', htmlspecialchars($currentremark), array('id' => '{NAME}-groups-{GROUP-id}-items-{ITEM-id}-remark-input',
+                $input = $labelforremark . html_writer::tag('textarea', htmlspecialchars($currentremark, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401), array('id' => '{NAME}-groups-{GROUP-id}-items-{ITEM-id}-remark-input',
                         'name' => '{NAME}[groups][{GROUP-id}][items][{ITEM-id}][remark]', 'cols' => '20', 'rows' => '3'));
                 $itemtemplate .= html_writer::tag('div', $input, array('class' => 'remark'));
             } else if ($mode == gradingform_checklist_controller::DISPLAY_EVAL_FROZEN) {

--- a/renderer.php
+++ b/renderer.php
@@ -424,7 +424,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
         $scoredpoints = 0;
         $cnt = 0;
         foreach ($groups as $id => $group) {
-            $group['class'] = $this->get_css_class_suffix($cnt++, sizeof($groups) -1);
+            $group['class'] = $this->get_css_class_suffix($cnt++, sizeof($groups) - 1);
             $group['id'] = $id;
             $itemsstr = '';
             $itemcnt = 0;
@@ -435,7 +435,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
             }
             foreach ($group['items'] as $itemid => $item) {
                 $item['id'] = $itemid;
-                $item['class'] = $this->get_css_class_suffix($itemcnt++, sizeof($group['items']) -1);
+                $item['class'] = $this->get_css_class_suffix($itemcnt++, sizeof($group['items']) - 1);
                 $item['checked'] = !empty($groupvalue['items'][$itemid]['checked']);
                 if ($item['checked'] && ($mode == gradingform_checklist_controller::DISPLAY_EVAL_FROZEN || $mode == gradingform_checklist_controller::DISPLAY_REVIEW || $mode == gradingform_checklist_controller::DISPLAY_VIEW)) {
                     $item['class'] .= ' checked';
@@ -487,7 +487,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
         if ($idx == $maxidx) {
             $class .= ' last';
         }
-        if ($idx%2) {
+        if ($idx % 2) {
             $class .= ' odd';
         } else {
             $class .= ' even';
@@ -542,7 +542,7 @@ class gradingform_checklist_renderer extends plugin_renderer_base {
 
     public function display_regrade_confirmation($elementname, $changelevel, $value) {
         $html = html_writer::start_tag('div', array('class' => 'gradingform_checklist-regrade'));
-        if ($changelevel<=2) {
+        if ($changelevel <= 2) {
             $html .= get_string('regrademessage1', 'gradingform_checklist');
             $selectoptions = array(
                 0 => get_string('regradeoption0', 'gradingform_checklist'),

--- a/tests/generator/checklist.php
+++ b/tests/generator/checklist.php
@@ -76,7 +76,7 @@ class checklist {
             'description_editor' => [
                 'text' => $this->description,
                 'format' => FORMAT_HTML,
-                'itemid' => 1
+                'itemid' => 1,
             ],
             'checklist' => [
                 'groups' => $this->get_all_criterion_values(),

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -198,10 +198,10 @@ class gradingform_checklist_generator extends component_generator_base {
     public function get_test_checklist(context $context, string $component, string $area): gradingform_checklist_controller {
         $criteria = [
             'Group 1' => [
-                'Has title' => 1
+                'Has title' => 1,
             ],
             'Group 2' => [
-                'Has references' => 1
+                'Has references' => 1,
             ],
         ];
 

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -61,10 +61,10 @@ class generator_test extends advanced_testcase {
         $description = 'My first checklist';
         $criteria = [
             'Group 1' => [
-                'Has title' => 1
+                'Has title' => 1,
             ],
             'Group 2' => [
-                'Has references' => 1
+                'Has references' => 1,
             ],
         ];
 
@@ -138,10 +138,10 @@ class generator_test extends advanced_testcase {
         $description = 'My first checklist';
         $criteria = [
             'Group 1' => [
-                'Has title' => 1
+                'Has title' => 1,
             ],
             'Group 2' => [
-                'Has references' => 1
+                'Has references' => 1,
             ],
         ];
 

--- a/version.php
+++ b/version.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify


### PR DESCRIPTION
**1. Fixed syntax in code formatting**
**2. Removed extra newline after the opening PHP tag.**
**3. Fixed array syntax issues**
**4. Updated htmlentities flags to ENT_QUOTES**
Adding ENT_QUOTES to htmlentities enhances security by converting both single and double quotes to HTML entities, preventing potential security issues related to character encoding.
**5. Replaced sizeof() with count().**
This change is due to the deprecation of sizeof(), and it's recommended to use count() instead. Both functions essentially do the same thing, but using count() is a more modern and preferred practice.
**https://stackoverflow.com/questions/3974385/php-array-count-or-sizeof**
**6. Removed extra space in the switch break statement**